### PR TITLE
feat: generate es2018 code for node 10+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6779,9 +6779,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "snyk-docker-pull",
   "description": "CLI-less docker pull",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
@@ -29,7 +30,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.3"
   },
   "dependencies": {
     "child-process": "^1.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es5",
+    "target": "es2018",
     "lib": [
-      "es2015"
+      "es2018"
     ],
     "module": "commonjs",
     "sourceMap": true,


### PR DESCRIPTION
This removes some uses of tslib's promises from the generated code,
and generally cleans up stack traces and error messages.
