### PR TITLE
feat: make snyk-docker-pull private

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "snyk-docker-pull",
+  "name": "@snyk/snyk-docker-pull",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "snyk-docker-pull",
+  "name": "@snyk/snyk-docker-pull",
   "description": "CLI-less docker pull",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,6 +20,9 @@
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "devDependencies": {
     "@types/jest": "^24.0.15",
     "@types/node": "^11.13.18",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

this package should be private as it's for internal use, uses internal env variables and uses private packages.
