### PR TITLE
feat: release as private package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/snyk/docker-pull.git"
   },
   "author": "snyk.io",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/jest": "^24.0.15",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Previous version failed publication as the NPM token was of a read only permissions. This forces release with valid token and new changes.
