### PR TITLE
fix: handle layers with equal sha256 digest

### DIFF
--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -173,6 +173,10 @@ export class DockerPull {
     for (const layerConfig of layersConfigs) {
       const digest = layerConfig.digest.replace("sha256:", "");
       const layerDir = path.join(imgDir, digest);
+      // layer might already exist
+      if (fs.existsSync(layerDir)) {
+        continue;
+      }
       fs.mkdirSync(layerDir);
 
       // write layer.tar


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Some images might contain layers with duplicate sha256 digest value.

For example, the layers part of `django:1.9.6`
```
> docker pull django:1.9.6
> docker inspect django:1.9.6
. . .
"Layers": [
                "sha256:4dcab49015d47e8f300ec33400a02cebc7b54cadd09c37e49eccbc655279da90",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:62932e169f5dbf1bf97a0b81a158b1f767e782b72dd5d1c05da3f817ad95c21d",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:5512f51485bf0c982cc9db1234f1c76b43c2928d185c1e3aad1aa1b9fcefaf5b",
                "sha256:17e6cef314a12842ba1546230c2814233d1a6aa8d7f934428121b872de11b054",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:f1f1e4c5c06d3737ba3677ed2d07bd0211c506a02e67052d9f6e1b8165d6eeb0",
                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
                "sha256:b8c7335e997d4aac65101c9f7f8687fa1eac8ccecac2a762d382c21465795473"
            ] 
. . .
```
### More information

- [Jira ticket DC-468](https://snyksec.atlassian.net/browse/DC-468)
