### PR TITLE
fix: publish code in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "format": "prettier --loglevel warn --write '**/*.ts'",
     "prepare": "npm run build"
   },
-  "files": [
-    "dist"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/snyk/docker-pull.git"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Following https://snyk.slack.com/archives/CJFQ1MQP6/p1580911068015400 @FauxFaux pointing out we don't actually publish code in the tar of the npm package, removing the field `files` that includes publishing only `dist` directory should solve it.

