### PR TITLE
fix: use an valid version of docker-registry-v2-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "child-process": "^1.0.2",
-    "@snyk/docker-registry-v2-client": "^1.11.0",
+    "@snyk/docker-registry-v2-client": "^1.12.3",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
     "tmp": "^0.1.0"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

After fixing release of docker-registry-v2-client with `dist` folder, we need to use a correct version of it. https://github.com/snyk/docker-registry-v2-client/pull/47/commits/805975074c230074729fea2f49104ac49997f065
