### PR TITLE
fix: Adding xform expression to work around some issues in the docker…

### DIFF
--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -217,7 +217,7 @@ export class DockerPull {
 
     await subProcess.execute(
       "tar",
-      ["cf", "image.tar", "-C", imgDir, "."],
+      ["cf", "image.tar", "--xform", "s:\\./\\?::", "-C", imgDir, "."],
       stagingDir.name
     );
 


### PR DESCRIPTION
### What this does

Adding an xform expression to work around an issue in the snyk-docker-plugin.
See: https://github.com/snyk/snyk-docker-plugin/issues/218

The xform argument executes a sed like replace expression on the file paths entries in the tar file.

So if a `tar tf image.tar` would return before something like:
./foo/bar

with the xform expression we return now:
foo/bar