### PR TITLE
feat: allow optional username/password

### DIFF
--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -15,6 +15,18 @@ export interface DockerPullResult {
   pullDuration: number;
 }
 
+export interface DockerPullOptions {
+  username?: string;
+  password?: string;
+  // weak typing on the client
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reqOptions?: any;
+  /**
+   * loadImage will default to true if no value is sent
+   */
+  loadImage?: boolean;
+}
+
 const DEFAULT_LAYER_JSON = {
   created: "0001-01-01T00:00:00Z",
   // eslint-disable-next-line @typescript-eslint/camelcase
@@ -50,23 +62,19 @@ export class DockerPull {
   }
 
   public async pull(
-    username: string,
-    password: string,
     registryBase: string,
     repo: string,
     tag: string,
-    // weak typing on the client
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    reqOptions = {} as any,
-    loadImage = true
+    opt?: DockerPullOptions
   ): Promise<DockerPullResult> {
+    const loadImage = opt?.loadImage === undefined ? true : opt.loadImage;
     const manifest: types.ImageManifest = await registryClient.getManifest(
       registryBase,
       repo,
       tag,
-      username,
-      password,
-      reqOptions
+      opt?.username,
+      opt?.password,
+      opt?.reqOptions
     );
 
     const imageConfigMetadata: types.LayerConfig = manifest.config;
@@ -74,19 +82,19 @@ export class DockerPull {
       registryBase,
       repo,
       imageConfigMetadata.digest,
-      username,
-      password,
-      reqOptions
+      opt?.username,
+      opt?.password,
+      opt?.reqOptions
     );
     const t0 = Date.now();
     const layersConfigs: types.LayerConfig[] = manifest.layers;
     const missingLayers = await this.getLayers(
       layersConfigs,
       registryBase,
-      username,
-      password,
       repo,
-      reqOptions
+      opt?.username,
+      opt?.password,
+      opt?.reqOptions
     );
     const pullDuration = Date.now() - t0;
 
@@ -125,9 +133,9 @@ export class DockerPull {
   private async getLayers(
     layersConfigs: types.LayerConfig[],
     registryBase,
-    username,
-    password,
     repo: string,
+    username?: string,
+    password?: string,
     // weak typing on the client
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     reqOptions = {} as any

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { DockerPull, DockerPullResult } from "./docker-pull";
+export { DockerPull, DockerPullOptions, DockerPullResult } from "./docker-pull";

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -1,4 +1,4 @@
-import { DockerPull } from "../../src/docker-pull";
+import { DockerPull, DockerPullOptions } from "../../src/docker-pull";
 import { removeImage } from "../utils";
 import * as path from "path";
 import * as fs from "fs";
@@ -6,19 +6,16 @@ import * as fs from "fs";
 jest.setTimeout(40000);
 
 test("private image pull and load", async () => {
-  const username = process.env.SNYK_DRA_DOCKER_HUB_USERNAME;
-  const password = process.env.SNYK_DRA_DOCKER_HUB_PASSWORD;
   const repo = process.env.SNYK_DRA_DOCKER_HUB_REPOSITORY;
+
+  const opt: DockerPullOptions = {
+    username: process.env.SNYK_DRA_DOCKER_HUB_USERNAME,
+    password: process.env.SNYK_DRA_DOCKER_HUB_PASSWORD
+  };
 
   const dockerPull: DockerPull = new DockerPull();
   const imageDigest: string = (
-    await dockerPull.pull(
-      username,
-      password,
-      "registry-1.docker.io",
-      repo,
-      "alpine"
-    )
+    await dockerPull.pull("registry-1.docker.io", repo, "alpine", opt)
   ).imageDigest;
   expect(imageDigest).toBeDefined();
 
@@ -26,21 +23,17 @@ test("private image pull and load", async () => {
 });
 
 test("private image pull and build", async () => {
-  const username = process.env.SNYK_DRA_DOCKER_HUB_USERNAME;
-  const password = process.env.SNYK_DRA_DOCKER_HUB_PASSWORD;
   const repo = process.env.SNYK_DRA_DOCKER_HUB_REPOSITORY;
+
+  const opt: DockerPullOptions = {
+    username: process.env.SNYK_DRA_DOCKER_HUB_USERNAME,
+    password: process.env.SNYK_DRA_DOCKER_HUB_PASSWORD,
+    loadImage: false
+  };
 
   const dockerPull: DockerPull = new DockerPull();
   const stagingDir = (
-    await dockerPull.pull(
-      username,
-      password,
-      "registry-1.docker.io",
-      repo,
-      "alpine",
-      {},
-      false
-    )
+    await dockerPull.pull("registry-1.docker.io", repo, "alpine", opt)
   ).stagingDir;
 
   expect(fs.existsSync(path.join(stagingDir.name, "image.tar"))).toBeTruthy();


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allows optional credentials to be passed to the pull method via a new `DockerPullOptions` type. Support for optional credentials is already available with the `docker-registry-v2-client` project, this just extends that functionality to this lib.