### PR TITLE
feat: remove reliance on tar binary, replace with tar-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/jest": "^25.1.1",
     "@types/node": "^10.17.14",
+    "@types/tar-stream": "^2.1.0",
     "@types/tmp": "^0.1.0",
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
@@ -36,8 +37,9 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^1.13.2",
+    "@snyk/docker-registry-v2-client": "^1.13.3",
     "child-process": "^1.0.2",
+    "tar-stream": "^2.1.2",
     "tmp": "^0.1.0"
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -10,18 +10,3 @@ export interface Layer {
 export const readDir = promisify(fs.readdir);
 export const readFile = promisify(fs.readFile);
 export const unlink = promisify(fs.unlink);
-
-export async function promiseWrite(
-  filePath: string,
-  buff: Buffer
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(filePath);
-    file.write(buff);
-    file.end();
-    file.on("finish", () => {
-      resolve();
-    });
-    file.on("error", reject);
-  });
-}

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -3,8 +3,9 @@ import * as registryClient from "@snyk/docker-registry-v2-client";
 import * as fs from "fs";
 import * as path from "path";
 import * as tmp from "tmp";
-import { Layer, promiseWrite } from "./common";
+import { Layer } from "./common";
 import * as subProcess from "./sub-process";
+import * as tar from "tar-stream";
 
 export interface DockerPullResult {
   imageDigest: string;
@@ -162,19 +163,12 @@ export class DockerPull {
     layers: Layer[],
     stagingDir: tmp.DirResult
   ): Promise<string> {
-    const imgDir = path.join(stagingDir.name, "image");
-    fs.mkdirSync(imgDir);
+    const pack = tar.pack();
 
     // write layers
     let parentDigest: string | undefined;
     for (const layerConfig of layersConfigs) {
       const digest = layerConfig.digest.replace("sha256:", "");
-      const layerDir = path.join(imgDir, digest);
-      // layer might already exist
-      if (fs.existsSync(layerDir)) {
-        continue;
-      }
-      fs.mkdirSync(layerDir);
 
       // write layer.tar
       let blob: Buffer;
@@ -187,26 +181,23 @@ export class DockerPull {
       if (!blob) {
         throw new Error(`missing blob during build: ${digest}`);
       }
-      await promiseWrite(path.join(layerDir, "layer.tar"), blob);
+      pack.entry({ name: path.join(digest, "layer.tar") }, blob);
 
       // write json
       let json: object = Object.assign({}, { id: digest }, DEFAULT_LAYER_JSON);
       if (parentDigest) {
         json = Object.assign({ parent: parentDigest });
       }
-      fs.writeFileSync(path.join(layerDir, "json"), JSON.stringify(json));
+      pack.entry({ name: path.join(digest, "json") }, JSON.stringify(json));
       parentDigest = digest;
 
       // write version
-      fs.writeFileSync(path.join(layerDir, "VERSION"), "1.0");
+      pack.entry({ name: path.join(digest, "VERSION") }, "1.0");
     }
 
     imageDigest = imageDigest.replace("sha256:", "");
     // write image json
-    fs.writeFileSync(
-      `${path.join(imgDir, imageDigest)}.json`,
-      JSON.stringify(imageConfig)
-    );
+    pack.entry({ name: `${imageDigest}.json` }, JSON.stringify(imageConfig));
 
     // write manifest.json
     const manifestJson = [
@@ -218,18 +209,15 @@ export class DockerPull {
         )
       }
     ];
-    fs.writeFileSync(
-      path.join(imgDir, "manifest.json"),
-      JSON.stringify(manifestJson)
-    );
+    pack.entry({ name: "manifest.json" }, JSON.stringify(manifestJson), () => {
+      pack.finalize();
+    });
 
-    await subProcess.execute(
-      "tar",
-      ["cf", "image.tar", "--xform", "s:\\./\\?::", "-C", imgDir, "."],
-      stagingDir.name
-    );
+    const imagePath = path.join(stagingDir.name, "image.tar");
+    const file = fs.createWriteStream(imagePath);
+    pack.pipe(file);
 
-    return path.join(stagingDir.name, "image.tar");
+    return path.join(imagePath);
   }
 
   private async loadImage(

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -1,5 +1,5 @@
 import { DockerPull, DockerPullOptions } from "../../src/docker-pull";
-import { removeImage } from "../utils";
+import { removeImage, listTar } from "../utils";
 import * as path from "path";
 import * as fs from "fs";
 
@@ -36,7 +36,8 @@ test("private image pull and build", async () => {
     await dockerPull.pull("registry-1.docker.io", repo, "alpine", opt)
   ).stagingDir;
 
-  expect(fs.existsSync(path.join(stagingDir.name, "image.tar"))).toBeTruthy();
+  const tarPath = path.join(stagingDir.name, "image.tar");
+  expect(fs.existsSync(tarPath)).toBeTruthy();
 
   stagingDir.removeCallback();
 });
@@ -51,9 +52,14 @@ test("pull from public repo", async () => {
 
   const dockerPull: DockerPull = new DockerPull();
   const resp = await dockerPull.pull(registry, repo, tag, opt);
-  expect(
-    fs.existsSync(path.join(resp.stagingDir.name, "image.tar"))
-  ).toBeTruthy();
+
+  const tarPath = path.join(resp.stagingDir.name, "image.tar");
+  expect(fs.existsSync(tarPath)).toBeTruthy();
+
+  const tarListing = await listTar(tarPath);
+  expect(tarListing.includes("manifest.json")).toBeTruthy();
+  expect(tarListing.includes("./manifest.json")).toBeFalsy();
+  tarListing.forEach(fileName => expect(fileName).not.toContain("./"));
 
   resp.stagingDir.removeCallback();
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,12 +1,17 @@
+import { createReadStream } from "fs";
+import { extract, Extract } from "tar-stream";
 import * as subProcess from "../src/sub-process";
+
+const DEFAULT_CWD = undefined;
+const DEFAULT_ENV = undefined;
 
 export async function removeImage(sha: string): Promise<subProcess.CmdOutput> {
   try {
     return await subProcess.execute(
       "docker",
       ["rmi", `${sha}`],
-      undefined,
-      undefined,
+      DEFAULT_CWD,
+      DEFAULT_ENV,
       true
     );
   } catch (err) {
@@ -15,4 +20,22 @@ export async function removeImage(sha: string): Promise<subProcess.CmdOutput> {
       throw new Error(stderr);
     }
   }
+}
+
+export async function listTar(tarFilePath): Promise<string[]> {
+  const tarExtractor: Extract = extract();
+  const tarFileNames = [];
+  await new Promise((resolve, reject) => {
+    tarExtractor.on("entry", async (header, stream, next) => {
+      tarFileNames.push(header.name);
+      stream.resume(); // auto drain the stream
+      next(); // ready for next entry
+    });
+
+    tarExtractor.on("finish", resolve);
+    tarExtractor.on("error", error => reject(error));
+
+    createReadStream(tarFilePath).pipe(tarExtractor);
+  });
+  return tarFileNames;
 }


### PR DESCRIPTION
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Replace the use of the `tar` binary on the local machine with `tar-stream`. I've verified the contents of the output tar on my local machine.

### More information

- [RUN-1000](https://snyksec.atlassian.net/browse/RUN-1000)