### PR TITLE
fix: Adding support for pull save requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-jest": "^23.6.0",
+    "glob": "^7.1.6",
     "jest": "^25.1.0",
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.0",

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -1,11 +1,17 @@
 import { types } from "@snyk/docker-registry-v2-client";
 import * as registryClient from "@snyk/docker-registry-v2-client";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import * as tmp from "tmp";
 import { Layer } from "./common";
 import * as subProcess from "./sub-process";
 import * as tar from "tar-stream";
+import { promisify } from "util";
+
+const readFile = promisify(fs.readFile);
+const link = promisify(fs.link);
+const stat = promisify(fs.stat);
 
 export interface DockerPullResult {
   imageDigest: string;
@@ -26,6 +32,17 @@ export interface DockerPullOptions {
    * loadImage will default to true if no value is sent
    */
   loadImage?: boolean;
+}
+
+interface SaveRequest {
+  username?: string;
+  registryBase?: string;
+  repo?: string;
+  tag?: string;
+}
+
+interface SaveRequests {
+  [name: string]: SaveRequest;
 }
 
 const DEFAULT_LAYER_JSON = {
@@ -117,6 +134,33 @@ export class DockerPull {
     } catch (err) {
       throw new Error(err.stderr);
     } finally {
+      try {
+        // Check is the image should be saved for debugging
+        const saveMatcher = {
+          ...opt,
+          registryBase,
+          repo,
+          tag
+        };
+        for (const [name, requestMatcher] of Object.entries(
+          await this.saveRequests()
+        )) {
+          if (
+            Object.keys(requestMatcher).every(
+              key => requestMatcher[key] === saveMatcher[key]
+            )
+          ) {
+            await link(
+              path.join(stagingDir.name, "image.tar"),
+              tmp.tmpNameSync({ prefix: `${name}-`, postfix: ".tar" })
+            );
+            break;
+          }
+        }
+      } catch (err) {
+        console.error("pullSaveRequest error: ", err);
+      }
+
       if (loadImage) {
         stagingDir.removeCallback();
       }
@@ -154,6 +198,17 @@ export class DockerPull {
         return { config, blob };
       })
     );
+  }
+
+  private async saveRequests(): Promise<SaveRequests> {
+    const saveRequestsPath = path.join(os.tmpdir(), "pullSaveRequest.json");
+    try {
+      if (await stat(saveRequestsPath)) {
+        return JSON.parse((await readFile(saveRequestsPath)).toString("utf-8"));
+      }
+    } catch (err) {
+      return {};
+    }
   }
 
   private async buildImage(

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -1,7 +1,9 @@
 import { DockerPull, DockerPullOptions } from "../../src/docker-pull";
 import { removeImage, listTar } from "../utils";
 import * as path from "path";
+import * as os from "os";
 import * as fs from "fs";
+import * as glob from "glob";
 
 jest.setTimeout(40000);
 
@@ -13,13 +15,29 @@ test("private image pull and load", async () => {
     password: process.env.SNYK_DRA_DOCKER_HUB_PASSWORD
   };
 
+  // Add pull save request
+  const pullSaveRequestPath = path.join(os.tmpdir(), "pullSaveRequest.json");
+  fs.writeFileSync(
+    pullSaveRequestPath,
+    `{
+  "foo" : {
+    "username" : "${process.env.SNYK_DRA_DOCKER_HUB_USERNAME}",
+    "repo" : "${process.env.SNYK_DRA_DOCKER_HUB_REPOSITORY}",
+    "tag" : "alpine"
+  }
+}`
+  );
+
   const dockerPull: DockerPull = new DockerPull();
   const imageDigest: string = (
     await dockerPull.pull("registry-1.docker.io", repo, "alpine", opt)
   ).imageDigest;
   expect(imageDigest).toBeDefined();
+  const containerArchives = glob.sync(path.join(os.tmpdir(), "foo-*.tar"));
+  expect(containerArchives.length).toBeGreaterThan(0);
 
   await removeImage(imageDigest);
+  fs.unlinkSync(pullSaveRequestPath);
 });
 
 test("private image pull and build", async () => {
@@ -31,15 +49,32 @@ test("private image pull and build", async () => {
     loadImage: false
   };
 
+  // Add pull save request
+  const pullSaveRequestPath = path.join(os.tmpdir(), "pullSaveRequest.json");
+  fs.writeFileSync(
+    pullSaveRequestPath,
+    `{
+  "foo" : {
+    "username" : "${process.env.SNYK_DRA_DOCKER_HUB_USERNAME}",
+    "repo" : "${process.env.SNYK_DRA_DOCKER_HUB_REPOSITORY}",
+    "tag" : "alpine"
+  }
+}`
+  );
+
   const dockerPull: DockerPull = new DockerPull();
   const stagingDir = (
     await dockerPull.pull("registry-1.docker.io", repo, "alpine", opt)
   ).stagingDir;
 
+  const containerArchives = glob.sync(path.join(os.tmpdir(), "foo-*.tar"));
+  expect(containerArchives.length).toBeGreaterThan(0);
+
   const tarPath = path.join(stagingDir.name, "image.tar");
   expect(fs.existsSync(tarPath)).toBeTruthy();
 
   stagingDir.removeCallback();
+  fs.unlinkSync(pullSaveRequestPath);
 });
 
 test("pull from public repo", async () => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We can now request that images which match a certain criteria (username, repo, tag, etc ...) are saved for later inspection.

The requests can be stored in a file and can look like this:
```
{
  "foo" : {
    "username" : "snykgoof",
    "repo" : "snykgoof/dockerhub-goof",
    "tag" : "alpine"
  },
  "bar" : {
    "repo" : "myrepo/myimage",
    "tag" : "latest"
  }
}
```

### Notes for the reviewer

Error handling is done here through a console.error as I the code doesn't use a logging library yet and I don't want to throw an exception if something goes wrong. This feature is really only for debugging purposes.

### More information

- [Jira ticket DC-834](https://snyksec.atlassian.net/browse/DC-834)
