### PR TITLE
Feat/include image save path option

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.0",
     "ts-node": "^8.6.2",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "mkdir-recursive": "^0.4.0"
   },
   "dependencies": {
     "@snyk/docker-registry-v2-client": "^1.13.5",

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -9,7 +9,12 @@ import * as subProcess from "./sub-process";
 import * as tar from "tar-stream";
 import { promisify } from "util";
 
-import { DockerPullOptions, DockerPullResult, SaveRequests } from "./types";
+import {
+  DockerPullOptions,
+  DockerPullResult,
+  SaveRequests,
+  DirResult
+} from "./types";
 
 const readFile = promisify(fs.readFile);
 const link = promisify(fs.link);
@@ -87,7 +92,9 @@ export class DockerPull {
     const pullDuration = Date.now() - t0;
 
     let imageDigest: string;
-    const stagingDir: tmp.DirResult = tmp.dirSync({ unsafeCleanup: true });
+    const stagingDir: DirResult = this.createDownloadedImageDestination(
+      opt?.imageSavePath
+    );
 
     try {
       await this.buildImage(
@@ -186,7 +193,7 @@ export class DockerPull {
     imageConfig: object,
     layersConfigs: types.LayerConfig[],
     layers: Layer[],
-    stagingDir: tmp.DirResult
+    stagingDir: DirResult
   ): Promise<string> {
     const pack = tar.pack();
 
@@ -249,7 +256,7 @@ export class DockerPull {
     registryBase: string,
     repo: string,
     tag: string,
-    stagingDir: tmp.DirResult
+    stagingDir: DirResult
   ): Promise<string> {
     const dockerBinary: string = await DockerPull.findDockerBinary();
     const stdout = (
@@ -268,5 +275,20 @@ export class DockerPull {
     ]);
 
     return imgDigest;
+  }
+
+  private createDownloadedImageDestination(imageSavePath?: string): DirResult {
+    if (!imageSavePath) {
+      return tmp.dirSync({ unsafeCleanup: true });
+    }
+
+    const dirResult: DirResult = {
+      name: imageSavePath,
+      removeCallback: () => {
+        /* do nothing */
+      }
+    };
+
+    return dirResult;
   }
 }

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -9,41 +9,11 @@ import * as subProcess from "./sub-process";
 import * as tar from "tar-stream";
 import { promisify } from "util";
 
+import { DockerPullOptions, DockerPullResult, SaveRequests } from "./types";
+
 const readFile = promisify(fs.readFile);
 const link = promisify(fs.link);
 const stat = promisify(fs.stat);
-
-export interface DockerPullResult {
-  imageDigest: string;
-  stagingDir: tmp.DirResult | null;
-  /** @deprecated caching is no longer used */
-  cachedLayersDigests: string[];
-  missingLayersDigests: string[];
-  pullDuration: number;
-}
-
-export interface DockerPullOptions {
-  username?: string;
-  password?: string;
-  // weak typing on the client
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  reqOptions?: any;
-  /**
-   * loadImage will default to true if no value is sent
-   */
-  loadImage?: boolean;
-}
-
-interface SaveRequest {
-  username?: string;
-  registryBase?: string;
-  repo?: string;
-  tag?: string;
-}
-
-interface SaveRequests {
-  [name: string]: SaveRequest;
-}
 
 const DEFAULT_LAYER_JSON = {
   created: "0001-01-01T00:00:00Z",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { DockerPull, DockerPullOptions, DockerPullResult } from "./docker-pull";
+export { DockerPull } from "./docker-pull";
+export { DockerPullOptions, DockerPullResult } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,11 @@
-import * as tmp from "tmp";
+export interface DirResult {
+  name: string;
+  removeCallback: () => void;
+}
 
 export interface DockerPullResult {
   imageDigest: string;
-  stagingDir: tmp.DirResult | null;
+  stagingDir: DirResult | null;
   /** @deprecated caching is no longer used */
   cachedLayersDigests: string[];
   missingLayersDigests: string[];
@@ -19,6 +22,7 @@ export interface DockerPullOptions {
    * loadImage will default to true if no value is sent
    */
   loadImage?: boolean;
+  imageSavePath?: string;
 }
 
 export interface SaveRequests {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,33 @@
+import * as tmp from "tmp";
+
+export interface DockerPullResult {
+  imageDigest: string;
+  stagingDir: tmp.DirResult | null;
+  /** @deprecated caching is no longer used */
+  cachedLayersDigests: string[];
+  missingLayersDigests: string[];
+  pullDuration: number;
+}
+
+export interface DockerPullOptions {
+  username?: string;
+  password?: string;
+  // weak typing on the client
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reqOptions?: any;
+  /**
+   * loadImage will default to true if no value is sent
+   */
+  loadImage?: boolean;
+}
+
+export interface SaveRequests {
+  [name: string]: SaveRequest;
+}
+
+interface SaveRequest {
+  username?: string;
+  registryBase?: string;
+  repo?: string;
+  tag?: string;
+}

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -1,9 +1,11 @@
-import { DockerPull, DockerPullOptions } from "../../src/docker-pull";
-import { removeImage, listTar } from "../utils";
 import * as path from "path";
 import * as os from "os";
 import * as fs from "fs";
 import * as glob from "glob";
+
+import { DockerPull } from "../../src/docker-pull";
+import { DockerPullOptions } from "../../src/types";
+import { removeImage, listTar } from "../utils";
 
 jest.setTimeout(40000);
 

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -2,10 +2,21 @@ import * as path from "path";
 import * as os from "os";
 import * as fs from "fs";
 import * as glob from "glob";
+import * as fx from "mkdir-recursive";
 
 import { DockerPull } from "../../src/docker-pull";
 import { DockerPullOptions } from "../../src/types";
 import { removeImage, listTar } from "../utils";
+
+function rmdirRecursive(customPath: string[]): void {
+  if (customPath.length < 2) {
+    return;
+  }
+
+  fs.rmdirSync(path.join(...customPath));
+  const next = customPath.slice(0, customPath.length - 1);
+  rmdirRecursive(next);
+}
 
 jest.setTimeout(40000);
 
@@ -84,13 +95,17 @@ test("pull from public repo", async () => {
   const repo = "library/hello-world";
   const tag = "latest";
   const opt: DockerPullOptions = {
-    loadImage: false
+    loadImage: false,
+    imageSavePath: "./custom/image/save/path"
   };
+  // the custom path won't be create by the lib
+  fx.mkdirSync(opt.imageSavePath);
 
   const dockerPull: DockerPull = new DockerPull();
   const resp = await dockerPull.pull(registry, repo, tag, opt);
 
   const tarPath = path.join(resp.stagingDir.name, "image.tar");
+  expect(tarPath).toBe(path.join(resp.stagingDir.name, "image.tar"));
   expect(fs.existsSync(tarPath)).toBeTruthy();
 
   const tarListing = await listTar(tarPath);
@@ -98,5 +113,9 @@ test("pull from public repo", async () => {
   expect(tarListing.includes("./manifest.json")).toBeFalsy();
   tarListing.forEach(fileName => expect(fileName).not.toContain("./"));
 
+  // it won't do nothing because we set imageSavePath
   resp.stagingDir.removeCallback();
+  // clean up
+  fs.unlinkSync(tarPath);
+  rmdirRecursive(opt.imageSavePath.split(path.sep));
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Includes the option `imageSavePath` that when it is set will indicate a path to save the downloaded image. If it's not set it will use a tmp path (`tmp.dirSync()`).

### Notes for the reviewer
 
It's important to note that I didn't change anything for the function `saveRequests` on line [181](https://github.com/snyk/snyk-docker-pull/blob/83b827519090d5611b52467452f4da844a84beb6/src/docker-pull.ts#L181). Also it's a question if it should be save in the same path or if it's something that is always in a tmp folder.

### More information

- [RUN-582](https://snyksec.atlassian.net/browse/RUN-582)
- [RUN-654](https://snyksec.atlassian.net/browse/RUN-654)

