### PR TITLE
chore: fix the node image version for semantic release works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ jobs:
           command: npm run build
   release:
     <<: *defaults
+    docker:
+      - image: node:10
     steps:
       - checkout_and_merge
       - run:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Change Node version on release step to 10, because Semantic Release only works on Node 10.

### Notes for the reviewer

This bug was introduced in the [PR](https://github.com/snyk/snyk-docker-pull/pull/83), when the support for Node 8 was included. 