### PR TITLE
fix: bump v2-client to serialize non-string error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mkdir-recursive": "^0.4.0"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "1.13.8",
+    "@snyk/docker-registry-v2-client": "1.13.9",
     "child-process": "^1.0.2",
     "tar-stream": "^2.1.2",
     "tmp": "^0.1.0"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

