### PR TITLE
fix: Update docker-registry-v2-client to fix exception [DC-1219]

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.1.1",
+    "@snyk/docker-registry-v2-client": "^2.1.2",
     "child-process": "^1.0.2",
     "tar-stream": "^2.1.2",
     "tmp": "^0.1.0"

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -90,6 +90,50 @@ test("private image pull and build", async () => {
   fs.unlinkSync(pullSaveRequestPath);
 });
 
+test.only("private multiarch manifest digest pull and build", async () => {
+  const repo = `${process.env.SNYK_DRA_DOCKER_HUB_REPOSITORY}-multiarch`;
+  const multiArchManifestDigestWithAmd64 =
+    "sha256:5e2cb9c57eaef5ab6c99e7f7620ebf3c1c580928cf450e155e1b6306c6dd1939";
+
+  const opt: DockerPullOptions = {
+    username: process.env.SNYK_DRA_DOCKER_HUB_USERNAME,
+    password: process.env.SNYK_DRA_DOCKER_HUB_PASSWORD,
+    loadImage: false
+  };
+
+  // Add pull save request
+  const pullSaveRequestPath = path.join(os.tmpdir(), "pullSaveRequest.json");
+  fs.writeFileSync(
+    pullSaveRequestPath,
+    `{
+  "foo" : {
+    "username" : "${process.env.SNYK_DRA_DOCKER_HUB_USERNAME}",
+    "repo" : "${repo}",
+    "tag" : "${multiArchManifestDigestWithAmd64}"
+  }
+}`
+  );
+
+  const dockerPull: DockerPull = new DockerPull();
+  const stagingDir = (
+    await dockerPull.pull(
+      "registry-1.docker.io",
+      repo,
+      multiArchManifestDigestWithAmd64,
+      opt
+    )
+  ).stagingDir;
+
+  const containerArchives = glob.sync(path.join(os.tmpdir(), "foo-*.tar"));
+  expect(containerArchives.length).toBeGreaterThan(0);
+
+  const tarPath = path.join(stagingDir.name, "image.tar");
+  expect(fs.existsSync(tarPath)).toBeTruthy();
+
+  stagingDir.removeCallback();
+  fs.unlinkSync(pullSaveRequestPath);
+});
+
 test("pull from public repo", async () => {
   const registry = "registry-1.docker.io";
   const repo = "library/hello-world";


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Updated docker-registry-v2-client to fix an issue when getting multiarch manifest by its digest returns a manifest list, which resulted in a 'cannot read property of undefined' exception, when trying to access the manifest.config.digest object (as there is no config object in manifest list). 
The latest fix in the v2-client lib makes sure the getManifest always returns a manifest.v2 object rather than a list (in case a list is returned the default linux/amd64 arch is chosen).

### Notes for the reviewer

More information can be found in the docker-registry-v2-client PR: https://github.com/snyk/docker-registry-v2-client/pull/62

### More information

- [Jira ticket DC-1219](https://snyksec.atlassian.net/browse/DC-1219)
