### PR TITLE
perf: Update docker-registry-v2-client to avoid redundant API calls [DC-1219]

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.1.2",
+    "@snyk/docker-registry-v2-client": "^2.1.3",
     "child-process": "^1.0.2",
     "tar-stream": "^2.1.2",
     "tmp": "^0.1.0"

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -90,7 +90,7 @@ test("private image pull and build", async () => {
   fs.unlinkSync(pullSaveRequestPath);
 });
 
-test.only("private multiarch manifest digest pull and build", async () => {
+test("private multiarch manifest digest pull and build", async () => {
   const repo = `${process.env.SNYK_DRA_DOCKER_HUB_REPOSITORY}-multiarch`;
   const multiArchManifestDigestWithAmd64 =
     "sha256:5e2cb9c57eaef5ab6c99e7f7620ebf3c1c580928cf450e155e1b6306c6dd1939";


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Latest update in docker-registry-v2-client included a performance improvement that reduces the amount of API calls in getManifest, in some scenarios.
This PR updates this version so that this change will take place in this library.

### Notes for the reviewer

More info about the improvement can be found in the docker-registry-v2-client PR: https://github.com/snyk/docker-registry-v2-client/pull/63

### More information

- [Jira ticket DC-1219](https://snyksec.atlassian.net/browse/DC-1219)
