### PR TITLE
fix: Update docker-registry-v2-client to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.1.3",
+    "@snyk/docker-registry-v2-client": "^2.2.1",
     "child-process": "^1.0.2",
     "tar-stream": "^2.1.2",
     "tmp": "^0.1.0"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Update docker-registry-v2-client to enable setting needle default timeout through environment variable.


### More information

- [Jira ticket DC-1162](https://snyksec.atlassian.net/browse/DC-1162)
- https://github.com/snyk/docker-registry-v2-client/pull/64
