### PR TITLE
feat: experimental - add option to return calculated layers digests [DC-1224]

### DIFF
--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -1,5 +1,6 @@
 import { types } from "@snyk/docker-registry-v2-client";
 import * as registryClient from "@snyk/docker-registry-v2-client";
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -148,7 +149,10 @@ export class DockerPull {
       stagingDir: loadImage ? null : stagingDir,
       cachedLayersDigests: [],
       missingLayersDigests: missingLayers.map(layer => layer.config.digest),
-      pullDuration
+      pullDuration,
+      missingLayersCalculatedDigests: opt.calculateMissingLayersDigests
+        ? missingLayers.map(layer => this.calculateLayerDigest(layer))
+        : []
     };
   }
 
@@ -175,6 +179,16 @@ export class DockerPull {
         return { config, blob };
       })
     );
+  }
+
+  private calculateLayerDigest(layer: Layer): string {
+    const hashAlgorithm = layer.config.digest.split(":")[0];
+    const calculatedDigest = crypto
+      .createHash(hashAlgorithm)
+      .update(layer.blob)
+      .digest("hex");
+
+    return `${hashAlgorithm}:${calculatedDigest}`;
   }
 
   private async saveRequests(): Promise<SaveRequests> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,12 @@ export interface DockerPullResult {
   stagingDir: DirResult | null;
   /** @deprecated caching is no longer used */
   cachedLayersDigests: string[];
+  // The digests of the missing layers as returned in the manifest
   missingLayersDigests: string[];
   pullDuration: number;
+  // Experimental: The digests calculated from the missing layers downloaded blobs.
+  // Added as an experimental tool, and may be removed in future versions.
+  missingLayersCalculatedDigests: string[];
 }
 
 export interface DockerPullOptions {
@@ -23,6 +27,10 @@ export interface DockerPullOptions {
    */
   loadImage?: boolean;
   imageSavePath?: string;
+  // Experimental. If set to true, calculate and return missing
+  // layers digests from downloaded blobs.
+  // Added as an experimental tool, and may be removed in future versions.
+  calculateMissingLayersDigests?: boolean;
 }
 
 export interface SaveRequests {

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -163,3 +163,38 @@ test("pull from public repo", async () => {
   fs.unlinkSync(tarPath);
   rmdirRecursive(opt.imageSavePath.split(path.sep));
 });
+
+describe("calculate missing layers digest", () => {
+  test("when set to true - should return calculated digests", async () => {
+    const registry = "registry-1.docker.io";
+    const repo = "library/hello-world";
+    const tag = "latest";
+    const opt: DockerPullOptions = {
+      loadImage: false,
+      calculateMissingLayersDigests: true
+    };
+    const dockerPull: DockerPull = new DockerPull();
+    const resp = await dockerPull.pull(registry, repo, tag, opt);
+    expect(resp.missingLayersCalculatedDigests).toEqual(
+      resp.missingLayersDigests
+    );
+
+    resp.stagingDir.removeCallback();
+  });
+
+  test("when set to false - should not return calculated digests", async () => {
+    const registry = "registry-1.docker.io";
+    const repo = "library/hello-world";
+    const tag = "latest";
+    const opt: DockerPullOptions = {
+      loadImage: false,
+      calculateMissingLayersDigests: false
+    };
+
+    const dockerPull: DockerPull = new DockerPull();
+    const resp = await dockerPull.pull(registry, repo, tag, opt);
+    expect(resp.missingLayersCalculatedDigests).toEqual([]);
+
+    resp.stagingDir.removeCallback();
+  });
+});


### PR DESCRIPTION

- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
This PR adds an experimental option to return missing layers digests, calculated by the actual downloaded layers blobs.

This is done in order to check whether 'Unexpected end of data' errors are caused by malformed downloaded layers data.

### More information

- [Jira ticket DC-1224](https://snyksec.atlassian.net/browse/DC-1224)

