### PR TITLE
feat: Throw error if getManifest returns v1 manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.2.1",
+    "@snyk/docker-registry-v2-client": "^2.2.2",
     "child-process": "^1.0.2",
     "tar-stream": "^2.1.2",
     "tmp": "^0.1.0"

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -16,6 +16,7 @@ import {
   SaveRequests,
   DirResult
 } from "./types";
+import { InvalidManifestSchemaVersionError } from "./errors";
 
 const readFile = promisify(fs.readFile);
 const link = promisify(fs.link);
@@ -70,6 +71,10 @@ export class DockerPull {
       opt?.password,
       opt?.reqOptions
     );
+
+    if (manifest.schemaVersion !== 2) {
+      throw new InvalidManifestSchemaVersionError(manifest.schemaVersion);
+    }
 
     const imageConfigMetadata: types.LayerConfig = manifest.config;
     const imageConfig = await registryClient.getImageConfig(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,5 @@
+export class InvalidManifestSchemaVersionError extends Error {
+  constructor(version: number) {
+    super(`Invalid manifest schema version ${version}`);
+  }
+}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR updated v2 library to version 2.2.2, which restores getManifest to return manifest of schema version v1 (in addition to v2).
Since v1 schema is not supported by snyk-docker-pull, we will now throw an error in case this schema version is being returned.

### More information

- [Slack thread](https://snyk.slack.com/archives/CBXS33GJY/p1623596288425300)
