### PR TITLE
feat: Add code to invalid schema version error

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,8 @@
 export class InvalidManifestSchemaVersionError extends Error {
+  public code: number;
+
   constructor(version: number) {
     super(`Invalid manifest schema version ${version}`);
+    this.code = 422;
   }
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR adds a 400 code field to the InvalidManifestSchemaVersionError (which indicates that the requested image manifest is not valid for the pulling). This code can later be used when catching the error, for example, to determine the appropriate log level.
