### PR TITLE
fix: tar wait to end event before calling next

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -28,8 +28,10 @@ export async function listTar(tarFilePath): Promise<string[]> {
   await new Promise((resolve, reject) => {
     tarExtractor.on("entry", async (header, stream, next) => {
       tarFileNames.push(header.name);
+      stream.on("end", () => {
+        next(); // ready for next entry
+      });
       stream.resume(); // auto drain the stream
-      next(); // ready for next entry
     });
 
     tarExtractor.on("finish", resolve);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

When extracting tar, wait for `end` event before calling next entry
see https://github.com/mafintosh/tar-stream#extracting

### More information

- [Jira ticket DC-1258](https://snyksec.atlassian.net/browse/DC-1258)
