### PR TITLE
build image wait for file close [DC-1258]

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@snyk/docker-registry-v2-client": "^2.2.2",
     "child-process": "^1.0.2",
-    "tar-stream": "^2.1.2",
-    "tmp": "^0.1.0"
+    "tar-stream": "^2.2.0",
+    "tmp": "^0.2.1"
   }
 }

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -268,7 +268,11 @@ export class DockerPull {
     const file = fs.createWriteStream(imagePath);
     pack.pipe(file);
 
-    return path.join(imagePath);
+    return new Promise(resolve => {
+      file.on("close", () => {
+        resolve(path.join(imagePath));
+      });
+    });
   }
 
   private async loadImage(


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We build a tar file with image contents, and save it to a temp folder in the file system. This fix waits for file close event before resolving the function's promise, in order to make sure that the caller of the function has all the expected contents inside the tar file before extracting it

### Notes for the reviewer

I'm _almost_ sure this fixes the 'Unexpected end of data' error that we constantly see

### More information

- [Jira ticket DC-1258](https://snyksec.atlassian.net/browse/DC-1258)


