### PR TITLE
fix: Bump docker-registry-v2-client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.3.0",
+    "@snyk/docker-registry-v2-client": "^2.5.1",
     "child-process": "^1.0.2",
     "tar-stream": "^2.2.0",
     "tmp": "^0.2.1"


### PR DESCRIPTION
This PR bumps the docker-registry-v2-client to add the removal accept header optimization needed for ECR.