### PR TITLE
fix: Bump CircleCI node version to 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   resource_class: small
   docker:
-    - image: circleci/node:10
+    - image: circleci/node:14
   working_directory: ~/snyk-docker-pull
 
 commands:
@@ -83,8 +83,6 @@ jobs:
           command: npm run build
   release:
     <<: *defaults
-    docker:
-      - image: node:10
     steps:
       - checkout_and_merge
       - run:


### PR DESCRIPTION

### What this does
This PR is bumping the node version used in CircleCI from node:10 to node:14

### More information
Discovered when trying to release a new docker-pull version
- [CircleCI](https://app.circleci.com/pipelines/github/snyk/snyk-docker-pull/185/workflows/f74bdfeb-6bbe-47a3-91a9-e9b8e56029e5/jobs/522)
