### PR TITLE
fix: bump docker-registry-v2-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.5.1",
+    "@snyk/docker-registry-v2-client": "^2.6.1",
     "child-process": "^1.0.2",
     "tar-stream": "^2.2.0",
     "tmp": "^0.2.1"


### PR DESCRIPTION
Upgrade of docker-registry-v2-client due to upgrade of
parse-link-header.
The previous version had a high severity vuln
https://security.snyk.io/vuln/SNYK-JS-PARSELINKHEADER-1582783

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)
