### PR TITLE
fix: use original oci config digest

### DIFF
--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -107,6 +107,7 @@ export class DockerPull {
     try {
       if (manifest?.manifestContentType === contentTypes.OCI_MANIFEST_V1) {
         await this.buildOCIImage(
+          imageConfigMetadata.digest,
           manifest,
           imageConfig,
           missingLayers,
@@ -221,6 +222,7 @@ export class DockerPull {
   }
 
   private async buildOCIImage(
+    imageDigest: string,
     manifest: types.ImageManifest,
     imageConfig: Record<string, unknown>,
     layers: Layer[],
@@ -234,11 +236,7 @@ export class DockerPull {
     }
 
     const configContent = JSON.stringify(imageConfig);
-    const configDigest = crypto
-      .createHash("sha256")
-      .update(configContent)
-      .digest("hex")
-      .toLowerCase();
+    const configDigest = imageDigest.replace("sha256:", "");
     pack.entry(
       { name: path.join("blobs", "sha256", configDigest) },
       configContent


### PR DESCRIPTION
### What this does

fix: use original OCI config digest.

### Notes for the reviewer

Calculating the digest of a config that has gone through deserialisation and serialisation produces a different digest than the one present in container registries.

This PR uses the config digest that is available as a low-cost fix. 

There are other instances of this happening (example: meta manifests), but choosing to ignore. Recommendation to expose byte stream in `docker-pull-v2-client` as a high cost fix to resolve deserialisation/serialisation issue.

### More information

- Jira ticket: https://snyksec.atlassian.net/browse/SUP-1641