### PR TITLE
[SUP-2357] feat: large layer support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 defaults: &defaults
   resource_class: small
   docker:
-    - image: cimg/node:18.15.0
+    - image: cimg/node:18.19
   working_directory: ~/snyk-docker-pull
 
 executors:
@@ -246,7 +246,7 @@ workflows:
             - Install
           matrix:
             parameters:
-              node-version: ['14.21', '16.19', '18.15']
+              node-version: ["14.21", "16.19", "18.15"]
           filters:
             branches:
               ignore:
@@ -276,5 +276,3 @@ workflows:
             branches:
               only:
                 - main
-
-

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.21",
     "@types/node": "^16.11.6",
-    "@types/tar-stream": "^2.2.0",
+    "@types/tar-fs": "^2.0.4",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
     "@typescript-eslint/parser": "^4.28.5",
     "eslint": "^7.22.0",
@@ -38,9 +38,9 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.9.0",
+    "@snyk/docker-registry-v2-client": "^2.11.0",
     "child-process": "^1.0.2",
-    "tar-stream": "^2.2.0"
+    "tar-fs": "^3.0.4"
   },
   "release": {
     "branches": [

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,7 +4,7 @@ import { promisify } from "util";
 
 export interface Layer {
   config: types.LayerConfig;
-  blob: Buffer;
+  blobName: string;
 }
 
 export const readDir = promisify(fs.readdir);

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -4,11 +4,12 @@ import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import * as tar from "tar-stream";
+import * as tar from "tar-fs";
 import { randomUUID } from "crypto";
 import { promisify } from "util";
 import { Layer } from "./common";
 import * as subProcess from "./sub-process";
+import * as tmp from "./tmp";
 
 import {
   DockerPullOptions,
@@ -89,7 +90,11 @@ export class DockerPull {
     );
     const t0 = Date.now();
     const layersConfigs: types.LayerConfig[] = manifest.layers;
-    const missingLayers = await this.getLayers(
+
+    const blobDir = tmp.dirSync();
+
+    const missingLayers = await this.downloadLayers(
+      blobDir,
       layersConfigs,
       registryBase,
       repo,
@@ -117,6 +122,7 @@ export class DockerPull {
           manifest,
           imageConfig,
           missingLayers,
+          blobDir,
           stagingDir
         );
       } else {
@@ -125,6 +131,7 @@ export class DockerPull {
           imageConfig,
           layersConfigs,
           missingLayers,
+          blobDir,
           stagingDir
         );
       }
@@ -162,6 +169,7 @@ export class DockerPull {
         console.error("pullSaveRequest error: ", err);
       }
 
+      blobDir.removeCallback();
       if (loadImage) {
         stagingDir.removeCallback();
       }
@@ -173,15 +181,13 @@ export class DockerPull {
       cachedLayersDigests: [],
       missingLayersDigests: missingLayers.map((layer) => layer.config.digest),
       pullDuration,
-      missingLayersCalculatedDigests: opt.calculateMissingLayersDigests
-        ? missingLayers.map((layer) => this.calculateLayerDigest(layer))
-        : [],
       indexDigest,
       manifestDigest,
     };
   }
 
-  private async getLayers(
+  private async downloadLayers(
+    blobDir: DirResult,
     layersConfigs: types.LayerConfig[],
     registryBase,
     repo: string,
@@ -193,7 +199,9 @@ export class DockerPull {
   ): Promise<Layer[]> {
     return await Promise.all(
       layersConfigs.map(async (config: types.LayerConfig) => {
-        const blob: Buffer = await registryClient.getLayer(
+        const blobName = crypto.randomUUID();
+        await registryClient.downloadLayer(
+          path.join(blobDir.name, blobName),
           registryBase,
           repo,
           config.digest,
@@ -201,19 +209,9 @@ export class DockerPull {
           password,
           reqOptions
         );
-        return { config, blob };
+        return { config, blobName };
       })
     );
-  }
-
-  private calculateLayerDigest(layer: Layer): string {
-    const hashAlgorithm = layer.config.digest.split(":")[0];
-    const calculatedDigest = crypto
-      .createHash(hashAlgorithm)
-      .update(layer.blob)
-      .digest("hex");
-
-    return `${hashAlgorithm}:${calculatedDigest}`;
   }
 
   private async saveRequests(): Promise<SaveRequests> {
@@ -232,58 +230,67 @@ export class DockerPull {
     manifest: types.ImageManifest,
     imageConfig: Record<string, unknown>,
     layers: Layer[],
+    blobDir: DirResult,
     stagingDir: DirResult
   ): Promise<string> {
-    const pack = tar.pack();
+    const pack = tar.pack(blobDir.name, {
+      // write layers
+      entries: layers.map((layer) => layer.blobName),
+      map(header) {
+        const layer = layers.find((layer) => layer.blobName == header.name);
+        const digest = layer.config.digest.replace("sha256:", "");
+        header.name = path.join("blobs", "sha256", digest);
+        return header;
+      },
+      finalize: false,
+      finish(pack) {
+        const configContent = JSON.stringify(imageConfig);
+        const configDigest = imageDigest.replace("sha256:", "");
+        pack.entry(
+          { name: path.join("blobs", "sha256", configDigest) },
+          configContent
+        );
 
-    for (const layer of layers) {
-      const digest = layer.config.digest.replace("sha256:", "");
-      pack.entry({ name: path.join("blobs", "sha256", digest) }, layer.blob);
-    }
+        // Ensure config digest and size is accurate following serialization round trip
+        manifest.config.digest = `sha256:${configDigest}`;
+        manifest.config.size = Buffer.byteLength(configContent, "utf8");
 
-    const configContent = JSON.stringify(imageConfig);
-    const configDigest = imageDigest.replace("sha256:", "");
-    pack.entry(
-      { name: path.join("blobs", "sha256", configDigest) },
-      configContent
-    );
+        // Unset properties added by docker-registry-v2-client
+        manifest.indexDigest = undefined;
+        manifest.manifestDigest = undefined;
+        manifest.manifestContentType = undefined;
 
-    // Ensure config digest and size is accurate following serialization round trip
-    manifest.config.digest = `sha256:${configDigest}`;
-    manifest.config.size = Buffer.byteLength(configContent, "utf8");
+        const manifestContent = JSON.stringify(manifest);
+        const manifestDigest = crypto
+          .createHash("sha256")
+          .update(manifestContent)
+          .digest("hex")
+          .toLowerCase();
+        pack.entry(
+          { name: path.join("blobs", "sha256", manifestDigest) },
+          manifestContent
+        );
 
-    // Unset properties added by docker-registry-v2-client
-    manifest.indexDigest = undefined;
-    manifest.manifestDigest = undefined;
-    manifest.manifestContentType = undefined;
+        const indexContent = JSON.stringify({
+          schemaVersion: 2,
+          mediaType: contentTypes.OCI_INDEX_V1,
+          manifests: [
+            {
+              mediaType: contentTypes.OCI_MANIFEST_V1,
+              size: Buffer.byteLength(manifestContent, "utf8"),
+              digest: `sha256:${manifestDigest}`,
+            },
+          ],
+        });
+        pack.entry({ name: "index.json" }, indexContent);
 
-    const manifestContent = JSON.stringify(manifest);
-    const manifestDigest = crypto
-      .createHash("sha256")
-      .update(manifestContent)
-      .digest("hex")
-      .toLowerCase();
-    pack.entry(
-      { name: path.join("blobs", "sha256", manifestDigest) },
-      manifestContent
-    );
-
-    const indexContent = JSON.stringify({
-      schemaVersion: 2,
-      mediaType: contentTypes.OCI_INDEX_V1,
-      manifests: [
-        {
-          mediaType: contentTypes.OCI_MANIFEST_V1,
-          size: Buffer.byteLength(manifestContent, "utf8"),
-          digest: `sha256:${manifestDigest}`,
-        },
-      ],
-    });
-    pack.entry({ name: "index.json" }, indexContent);
-
-    const ociLayoutContent = JSON.stringify({ imageLayoutVersion: "1.0.0" });
-    pack.entry({ name: "oci-layout" }, ociLayoutContent, () => {
-      pack.finalize();
+        const ociLayoutContent = JSON.stringify({
+          imageLayoutVersion: "1.0.0",
+        });
+        pack.entry({ name: "oci-layout" }, ociLayoutContent, () => {
+          pack.finalize();
+        });
+      },
     });
 
     const imagePath = path.join(stagingDir.name, "image.tar");
@@ -301,29 +308,14 @@ export class DockerPull {
     imageConfig: Record<string, unknown>,
     layersConfigs: types.LayerConfig[],
     layers: Layer[],
+    blobDir: DirResult,
     stagingDir: DirResult
   ): Promise<string> {
-    const pack = tar.pack();
-
-    // write layers
+    // generate layer metadata
     let parentDigest: string | undefined;
+    const layerMetadata: Record<string, { version: string; json: string }> = {};
     for (const layerConfig of layersConfigs) {
       const digest = layerConfig.digest.replace("sha256:", "");
-
-      // write layer.tar
-      let blob: Buffer;
-      for (const layer of layers) {
-        if (layerConfig.digest === layer.config.digest) {
-          blob = layer.blob;
-          break;
-        }
-      }
-      if (!blob) {
-        throw new Error(`missing blob during build: ${digest}`);
-      }
-      pack.entry({ name: path.join(digest, "layer.tar") }, blob);
-
-      // write json
       let json: Record<string, unknown> = Object.assign(
         {},
         { id: digest },
@@ -332,39 +324,66 @@ export class DockerPull {
       if (parentDigest) {
         json = Object.assign({ parent: parentDigest });
       }
-      pack.entry({ name: path.join(digest, "json") }, JSON.stringify(json));
       parentDigest = digest;
-
-      // write version
-      pack.entry({ name: path.join(digest, "VERSION") }, "1.0");
+      layerMetadata[digest] = {
+        json: JSON.stringify(json),
+        version: "1.0",
+      };
     }
 
-    imageDigest = imageDigest.replace("sha256:", "");
-    // write image json
-    pack.entry({ name: `${imageDigest}.json` }, JSON.stringify(imageConfig));
-
-    // write manifest.json
-    const manifestJson = [
-      {
-        Config: `${imageDigest}.json`,
-        RepoTags: null,
-        Layers: layersConfigs.map(
-          (config) => `${config.digest.replace("sha256:", "")}/layer.tar`
-        ),
+    const pack = tar.pack(blobDir.name, {
+      // write layers
+      entries: layers.map((layer) => layer.blobName),
+      map(header) {
+        const layer = layers.find((layer) => layer.blobName === header.name);
+        const digest = layer.config.digest.replace("sha256:", "");
+        header.name = path.join(digest, "layer.tar");
+        return header;
       },
-    ];
-    pack.entry({ name: "manifest.json" }, JSON.stringify(manifestJson), () => {
-      pack.finalize();
+      finalize: false,
+      finish(pack) {
+        // write layer metadata
+        for (const digest of Object.keys(layerMetadata)) {
+          const metadata = layerMetadata[digest];
+          pack.entry({ name: path.join(digest, "json") }, metadata.json);
+          pack.entry({ name: path.join(digest, "VERSION") }, metadata.version);
+        }
+
+        imageDigest = imageDigest.replace("sha256:", "");
+
+        // write image json
+        pack.entry(
+          { name: `${imageDigest}.json` },
+          JSON.stringify(imageConfig)
+        );
+
+        // write manifest.json
+        const manifestJson = [
+          {
+            Config: `${imageDigest}.json`,
+            RepoTags: null,
+            Layers: layersConfigs.map(
+              (config) => `${config.digest.replace("sha256:", "")}/layer.tar`
+            ),
+          },
+        ];
+        pack.entry(
+          { name: "manifest.json" },
+          JSON.stringify(manifestJson),
+          () => {
+            pack.finalize();
+          }
+        );
+      },
     });
 
     const imagePath = path.join(stagingDir.name, "image.tar");
     const file = fs.createWriteStream(imagePath);
     pack.pipe(file);
 
-    return new Promise((resolve) => {
-      file.on("close", () => {
-        resolve(path.join(imagePath));
-      });
+    return new Promise((resolve, reject) => {
+      file.on("close", () => resolve(path.join(imagePath)));
+      file.on("error", (err) => reject(err));
     });
   }
 
@@ -398,20 +417,14 @@ export class DockerPull {
     imageSavePath: string | undefined
   ): DirResult {
     if (!imageSavePath) {
-      const name = fs.mkdtempSync(stagingDirPath + path.sep);
-      return {
-        name,
-        removeCallback: (): void => fs.rmSync(name, { recursive: true }),
-      };
+      return tmp.dirSync({ path: stagingDirPath });
     }
 
-    const dirResult: DirResult = {
+    return {
       name: imageSavePath,
       removeCallback: (): void => {
         /* do nothing */
       },
     };
-
-    return dirResult;
   }
 }

--- a/src/tmp.ts
+++ b/src/tmp.ts
@@ -1,0 +1,17 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { DirResult } from "./types";
+
+/**
+ * Creates a temporary directory.
+ */
+export function dirSync(options?: { path?: string }): DirResult {
+  const name = fs.mkdtempSync(`${options?.path ?? os.tmpdir()}${path.sep}`);
+  return {
+    name,
+    removeCallback(): void {
+      fs.rmSync(name, { recursive: true });
+    },
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,6 @@ export interface DockerPullResult {
   // The digests of the missing layers as returned in the manifest
   missingLayersDigests: string[];
   pullDuration: number;
-  // Experimental: The digests calculated from the missing layers downloaded blobs.
-  // Added as an experimental tool, and may be removed in future versions.
-  missingLayersCalculatedDigests: string[];
   indexDigest?: string;
   manifestDigest?: string;
 }
@@ -29,10 +26,6 @@ export interface DockerPullOptions {
    */
   loadImage?: boolean;
   imageSavePath?: string;
-  // Experimental. If set to true, calculate and return missing
-  // layers digests from downloaded blobs.
-  // Added as an experimental tool, and may be removed in future versions.
-  calculateMissingLayersDigests?: boolean;
   stagingDirPath?: string;
 }
 

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -334,6 +334,12 @@ test("pull from public repo", async () => {
   const opt: DockerPullOptions = {
     loadImage: false,
     imageSavePath: "./custom/image/save/path",
+    reqOptions: {
+      acceptManifest: [
+        contentTypes.OCI_INDEX_V1,
+        contentTypes.OCI_MANIFEST_V1,
+      ].join(","),
+    },
   };
   // the custom path won't be create by the lib
   fx.mkdirSync(opt.imageSavePath);
@@ -349,8 +355,8 @@ test("pull from public repo", async () => {
   expect(fs.existsSync(tarPath)).toBeTruthy();
 
   const tarListing = await listTar(tarPath);
-  expect(tarListing.includes("manifest.json")).toBeTruthy();
-  expect(tarListing.includes("./manifest.json")).toBeFalsy();
+  expect(tarListing.includes("index.json")).toBeTruthy();
+  expect(tarListing.includes("./index.json")).toBeFalsy();
   tarListing.forEach((fileName) => expect(fileName).not.toContain("./"));
 
   // it won't do nothing because we set imageSavePath
@@ -358,39 +364,4 @@ test("pull from public repo", async () => {
   // clean up
   fs.unlinkSync(tarPath);
   rmdirRecursive(opt.imageSavePath.split(path.sep));
-});
-
-describe("calculate missing layers digest", () => {
-  test("when set to true - should return calculated digests", async () => {
-    const registry = "registry-1.docker.io";
-    const repo = "library/hello-world";
-    const tag = "latest";
-    const opt: DockerPullOptions = {
-      loadImage: false,
-      calculateMissingLayersDigests: true,
-    };
-    const dockerPull: DockerPull = new DockerPull();
-    const resp = await dockerPull.pull(registry, repo, tag, opt);
-    expect(resp.missingLayersCalculatedDigests).toEqual(
-      resp.missingLayersDigests
-    );
-
-    resp.stagingDir.removeCallback();
-  });
-
-  test("when set to false - should not return calculated digests", async () => {
-    const registry = "registry-1.docker.io";
-    const repo = "library/hello-world";
-    const tag = "latest";
-    const opt: DockerPullOptions = {
-      loadImage: false,
-      calculateMissingLayersDigests: false,
-    };
-
-    const dockerPull: DockerPull = new DockerPull();
-    const resp = await dockerPull.pull(registry, repo, tag, opt);
-    expect(resp.missingLayersCalculatedDigests).toEqual([]);
-
-    resp.stagingDir.removeCallback();
-  });
 });


### PR DESCRIPTION
### What this does

feat: large layer support

uses `downloadLayer` to download layer directly to disk instead of `getLayer` which downloads layer into memory, causing high memory consumption and NodeJS buffer errors whiles trying to allocate 4GB+ buffers.

### More information

- Jira ticket: https://snyksec.atlassian.net/browse/SUP-2357