### PR TITLE
fix: save temporary layers under the staging directory

### DIFF
--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -91,7 +91,11 @@ export class DockerPull {
     const t0 = Date.now();
     const layersConfigs: types.LayerConfig[] = manifest.layers;
 
-    const blobDir = tmp.dirSync();
+    const stagingDirPath = opt.stagingDirPath
+      ? opt.stagingDirPath
+      : os.tmpdir();
+
+    const blobDir = tmp.dirSync({ path: stagingDirPath });
 
     const missingLayers = await this.downloadLayers(
       blobDir,
@@ -102,11 +106,6 @@ export class DockerPull {
       opt?.password,
       opt?.reqOptions
     );
-
-    const stagingDirPath = opt.stagingDirPath
-      ? opt.stagingDirPath
-      : os.tmpdir();
-
     const pullDuration = Date.now() - t0;
 
     let imageDigest: string;

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -334,6 +334,7 @@ test("pull from public repo", async () => {
   const opt: DockerPullOptions = {
     loadImage: false,
     imageSavePath: "./custom/image/save/path",
+    stagingDirPath: "./tmp",
     reqOptions: {
       acceptManifest: [
         contentTypes.OCI_INDEX_V1,
@@ -343,6 +344,7 @@ test("pull from public repo", async () => {
   };
   // the custom path won't be create by the lib
   fx.mkdirSync(opt.imageSavePath);
+  fx.mkdirSync(opt.stagingDirPath);
 
   const dockerPull: DockerPull = new DockerPull();
   const resp = await dockerPull.pull(registry, repo, tag, opt);
@@ -364,4 +366,5 @@ test("pull from public repo", async () => {
   // clean up
   fs.unlinkSync(tarPath);
   rmdirRecursive(opt.imageSavePath.split(path.sep));
+  rmdirRecursive(opt.stagingDirPath.split(path.sep));
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

In #122 individual layers were saved on disk in temporary folders. These were automatically created in the `/tmp` folder, which is a change in the previous behaviour and might potentially be a breaking change for some clients.

This plugin already exposes a `stagingDirPath` option. If this option was provided all temporary files and directories were created under it, except for the new layers.

This PR makes sure that layers are saved under the `stagingDirPath` directory, if that option is provided.

This fix is currently required by `container-image-collector. See https://snyksec.atlassian.net/browse/LUM-911
