### PR TITLE
feat: support platform when retrieving image manifest UNIFY-163

### DIFF
--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -69,7 +69,8 @@ export class DockerPull {
       tag,
       opt?.username,
       opt?.password,
-      opt?.reqOptions
+      opt?.reqOptions,
+      opt?.platform
     );
 
     const indexDigest = manifest.indexDigest ?? undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { types } from "@snyk/docker-registry-v2-client";
+
 export interface DirResult {
   name: string;
   removeCallback: () => void;
@@ -27,6 +29,7 @@ export interface DockerPullOptions {
   loadImage?: boolean;
   imageSavePath?: string;
   stagingDirPath?: string;
+  platform?: types.Platform;
 }
 
 export interface SaveRequests {

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -365,3 +365,52 @@ test("pull from public repo", async () => {
   fs.unlinkSync(tarPath);
   rmdirRecursive(opt.imageSavePath.split(path.sep));
 });
+
+test("pull from public repo arm64 image architecture", async () => {
+  const registry = "registry-1.docker.io";
+  const repo = "library/debian";
+  const tag = "12.0";
+  const os = "linux";
+  const arch = "arm64";
+  const debianArm64ManifestDigest =
+    "sha256:345b9265e89c123f994b724b9a4761dbc91c5759c144d01292ca56a338170801";
+  const arm64IndexDigest =
+    "sha256:3d868b5eb908155f3784317b3dda2941df87bbbbaa4608f84881de66d9bb297b";
+
+  const opt: DockerPullOptions = {
+    loadImage: false,
+    imageSavePath: "./custom/image/save/path",
+    reqOptions: {
+      acceptManifest: [
+        contentTypes.OCI_INDEX_V1,
+        contentTypes.OCI_MANIFEST_V1,
+        contentTypes.MANIFEST_V2,
+        contentTypes.MANIFEST_LIST_V2,
+      ].join(","),
+    },
+    platform: { os: os, architecture: arch },
+  };
+  // the custom path won't be create by the lib
+  fx.mkdirSync(opt.imageSavePath);
+
+  const dockerPull: DockerPull = new DockerPull();
+  const resp = await dockerPull.pull(registry, repo, tag, opt);
+
+  const manifestDigest = resp.manifestDigest;
+  const indexDigest = resp.indexDigest;
+
+  expect(manifestDigest).toBeDefined();
+  expect(indexDigest).toBeDefined();
+
+  expect(manifestDigest).toEqual(debianArm64ManifestDigest);
+  expect(indexDigest).toEqual(arm64IndexDigest);
+  const tarPath = path.join(resp.stagingDir.name, "image.tar");
+  expect(tarPath).toBe(path.join(resp.stagingDir.name, "image.tar"));
+  expect(fs.existsSync(tarPath)).toBeTruthy();
+
+  // it won't do nothing because we set imageSavePath
+  resp.stagingDir.removeCallback();
+  // clean up
+  fs.unlinkSync(tarPath);
+  rmdirRecursive(opt.imageSavePath.split(path.sep));
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds support for platform argument when pulling the image manifest from registry

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- Jira ticket: https://snyksec.atlassian.net/browse/UNIFY-163
- Slack thread: https://snyk.slack.com/archives
- Documentation: N/A

### Screenshots

_Visuals that may help the reviewer_
