### PR TITLE
OI-471: Change repo ownership from orchestration-integrations to test-enrichment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
       - image: cimg/base:stable
   linux: # a Linux VM running Ubuntu 20.04
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:current
 
 commands:
   install_deps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
-          channel: team-integrations-alerts
+          channel: snyk-on-snyk-analysis_test-enrichment
 
       - install:
           name: Install
@@ -205,7 +205,7 @@ workflows:
       - security-scans:
           name: Security Scans
           context:
-            - analysis_integrations
+            - analysis_test-enrichment
           requires:
             - Install
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/orchestration-integrations
+* @snyk/test-enrichment

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,8 @@ metadata:
   name: snyk-docker-pull
   annotations:
     github.com/project-slug: snyk/snyk-docker-pull
-    github.com/team-slug: snyk/orchestration-integrations
+    github.com/team-slug: snyk/test-enrichment
 spec:
   type: internal-library
   lifecycle: "-"
-  owner: orchestration-integrations
+  owner: test-enrichment

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -1,18 +1,18 @@
-import * as path from "path";
-import * as os from "os";
 import * as fs from "fs";
 import * as glob from "glob";
 import * as fx from "mkdir-recursive";
+import * as os from "os";
+import * as path from "path";
 
+import { contentTypes } from "@snyk/docker-registry-v2-client";
 import { DockerPull } from "../../src/docker-pull";
 import { DockerPullOptions } from "../../src/types";
 import {
-  removeImage,
-  listTar,
   getTarFileContents,
   getTarFileDigest,
+  listTar,
+  removeImage,
 } from "../utils";
-import { contentTypes } from "@snyk/docker-registry-v2-client";
 
 function rmdirRecursive(customPath: string[]): void {
   if (customPath.length < 2) {
@@ -419,14 +419,17 @@ test("pull from public repo arm64/v8 image architecture", async () => {
 test("pull from public repo arm/v7 image architecture", async () => {
   const registry = "registry-1.docker.io";
   const repo = "library/debian";
-  const tag = "unstable-slim";
+  // tags are mutable, so use a tag with a date for Debian, to reduce the chance of SHAs changing underneath,
+  // which would lead to a test failure. Even with dates, this test is prone to failures caused by an update of the
+  // image the tag points to.
+  const tag = "unstable-20240926-slim";
   const os = "linux";
   const arch = "arm";
   const variant = "v7";
   const debianArmv7ManifestDigest =
-    "sha256:11e548e55f0276e86a890464c6f9e8c36ff066f2c524eab49286efabccd6cc12";
+    "sha256:40a73b80ed6aa92fd449dd7471630189c4bf594507a557ca3d95060a7779c7e4";
   const armv7IndexDigest =
-    "sha256:7a9076851517a85143d65add8ebb7abff5dd7017cdfb3f570a81d690289be88b";
+    "sha256:bfdb0ef563e702dbf3f1dfd79916d1e0fc21d7dc4b1a29720598f373b3cd4025";
 
   const opt: DockerPullOptions = {
     loadImage: false,

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -427,7 +427,7 @@ test("pull from public repo arm/v7 image architecture", async () => {
   const arch = "arm";
   const variant = "v7";
   const debianArmv7ManifestDigest =
-    "sha256:40a73b80ed6aa92fd449dd7471630189c4bf594507a557ca3d95060a7779c7e4";
+    "sha256:f7e37a581e0adb1cfa0f07c7671a7b0967095552bb5ebf04156724095ab12dd3";
   const armv7IndexDigest =
     "sha256:bfdb0ef563e702dbf3f1dfd79916d1e0fc21d7dc4b1a29720598f373b3cd4025";
 

--- a/test/src/docker-pull.test.ts
+++ b/test/src/docker-pull.test.ts
@@ -420,8 +420,10 @@ test("pull from public repo arm/v7 image architecture", async () => {
   const registry = "registry-1.docker.io";
   const repo = "library/debian";
   // tags are mutable, so use a tag with a date for Debian, to reduce the chance of SHAs changing underneath,
-  // which would lead to a test failure. Even with dates, this test is prone to failures caused by an update of the
-  // image the tag points to.
+  // which would lead to a test failure. Tags like "latest" or "unstable-slim" change frequently, because they point
+  // to the most recent image created, while the ones with dates are pointing to a set date when the image was built.
+  // Even with date tags, this test is prone to failures caused by an update of the image the tag points to, like when
+  // older images receive a security patch and are rebuilt.
   const tag = "unstable-20240926-slim";
   const os = "linux";
   const arch = "arm";
@@ -472,13 +474,13 @@ test("pull from public repo arm/v7 image architecture", async () => {
 test("pull from public repo linux/386 image architecture", async () => {
   const registry = "registry-1.docker.io";
   const repo = "library/alpine";
-  const tag = "latest";
+  const tag = "3.20";
   const os = "linux";
   const arch = "386";
   const linuxManifestDigest =
-    "sha256:ac77ebc035f69184acb2660028580c9053f6d0f892de7933e1456d8b5e0ac085";
+    "sha256:b3e87f642f5c48cdc7556c3e03a0d63916bd0055ba6edba7773df3cb1a76f224";
   const linuxIndexDigest =
-    "sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0";
+    "sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d";
 
   const opt: DockerPullOptions = {
     loadImage: false,


### PR DESCRIPTION
OI-471: Change repo ownership from orchestration-integrations to test-enrichment in `.github/CODEOWNERS`, `.circleci/config.yml` (snyk circleci context, secrets alerts channel) and `catalog-info.yaml` (github.com/team-slug, owner)

-- 
Generated by [Octopilot](https://github.com/dailymotion-oss/octopilot) [v1.12.15](https://github.com/dailymotion-oss/octopilot/releases/tag/v1.12.15) from https://github.com/snyk/prodsec-tools-v2