### PR TITLE
fix: downgrade semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
           command: npm run build
       - run:
           name: Release on GitHub
-          command: npx semantic-release@24.2.9
+          command: npx semantic-release
 workflows:
   version: 2
   test_and_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
           command: npm run build
       - run:
           name: Release on GitHub
-          command: npx semantic-release
+          command: npx semantic-release@24.2.9
 workflows:
   version: 2
   test_and_release:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": "^24.10.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^22.14.0"
+    "node": ">=12"
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^24.10.0"
+    "node": "^22.14.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "prettier": "^2.7.1",
     "ts-jest": "^26.5.4",
     "ts-node": "^10.4.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "semantic-release": "^22.0.12"
   },
   "dependencies": {
     "@snyk/docker-registry-v2-client": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ts-jest": "^26.5.4",
     "ts-node": "^10.4.0",
     "typescript": "^4.7.4",
-    "semantic-release": "^22.0.12"
+    "semantic-release": "^19.0.5"
   },
   "dependencies": {
     "@snyk/docker-registry-v2-client": "^2.20.0",


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Fixes an [issue](https://app.circleci.com/pipelines/github/snyk/snyk-docker-pull/400/workflows/407989c4-c9d1-4b0e-8f98-979e2dd9e612/jobs/1670?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) where CircleCI's `Release on GitHub` step would fail because `semantic-release` no longer supports node v18.

### Notes for the reviewer
The fix was adding a dev dependency for compatible version of `semantic-release` into `package.json`.

To test you can run this command, and confirm the correct version is output
```
ianvidal@KQ0HL976HL snyk-docker-pull % npx semantic-release --version                                                            
22.0.12
```
If you're still running the latest version of `semantic-release`, you'll see this error populate
```
ianvidal@KQ0HL976HL snyk-docker-pull % npx semantic-release --version
[semantic-release]: node version >=20.8.1 is required. Found v18.20.8.
```
### More information
- Slack thread: https://snyk.slack.com/archives/C08RUP1757B/p1768925958486849
- Release notes for semantic-release@25.0.0: https://github.com/semantic-release/semantic-release/releases/tag/v25.0.0
- Release notes for semantic-release@23.0.0: https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0
