### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/infrasec_container
+* @snyk/infrasec_container @snyk/container_container

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,74 @@
+version: v1.5.0
+ignore:
+  SNYK-JS-HANDLEBARS-15803082:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-HANDLEBARS-15803084:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-HANDLEBARS-15803086:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-HANDLEBARS-15807040:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-HANDLEBARS-15807042:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-ISAACSBRACEEXPANSION-15208653:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-LODASHES-15869627:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-MINIMATCH-15309438:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-MINIMATCH-15353387:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-MINIMATCH-15353389:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-PICOMATCH-15765511:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-TAR-15307072:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-TAR-15416075:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-TAR-15456201:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-UNDICI-15518064:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-UNDICI-15518066:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-UNDICI-15518068:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z
+  SNYK-JS-UNDICI-15518070:
+    - '*':
+        reason: 'Weeklong ignore - pre-commit security scan'
+        expires: 2026-04-16T00:00:00.000Z


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check:
- https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change
[!IMPORTANT]:
If this service relies on vervet, you will need to run a command to regenerate the spec (e.g. `make generate`) before merging it.
The best option is to:
- checkout the branch `update-ownership-PRODSEC-10215-fuFV`
- run the command
- commit and push the results to this PR before you approve and merge it.