### PR TITLE
feat: enable registry client v3 SSRF protections

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "semantic-release": "^19.0.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^2.20.0",
+    "@snyk/docker-registry-v2-client": "^3.0.0",
     "child-process": "^1.0.2",
     "tar-fs": "^3.0.9"
   },

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -73,7 +73,8 @@ export class DockerPull {
       opt?.username,
       opt?.password,
       opt?.reqOptions,
-      opt?.platform
+      opt?.platform,
+      opt?.observer
     );
 
     const indexDigest = manifest.indexDigest ?? undefined;
@@ -90,7 +91,8 @@ export class DockerPull {
       imageConfigMetadata.digest,
       opt?.username,
       opt?.password,
-      opt?.reqOptions
+      opt?.reqOptions,
+      opt?.observer
     );
     const t0 = Date.now();
     const layersConfigs: types.LayerConfig[] = manifest.layers;
@@ -104,7 +106,8 @@ export class DockerPull {
       repo,
       opt?.username,
       opt?.password,
-      opt?.reqOptions
+      opt?.reqOptions,
+      opt?.observer
     );
 
     const stagingDirPath = opt.stagingDirPath
@@ -199,7 +202,8 @@ export class DockerPull {
     password?: string,
     // weak typing on the client
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    reqOptions = {} as any
+    reqOptions = {} as any,
+    observer?: types.ContainerRegistryClientObserver
   ): Promise<Layer[]> {
     return await Promise.all(
       layersConfigs.map(async (config: types.LayerConfig) => {
@@ -211,7 +215,8 @@ export class DockerPull {
           config.digest,
           username,
           password,
-          reqOptions
+          reqOptions,
+          observer
         );
         return { config, blobName };
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+import type { types } from "@snyk/docker-registry-v2-client";
+
 export { DockerPull } from "./docker-pull";
 export { DockerPullOptions, DockerPullResult } from "./types";
 export { InvalidManifestSchemaVersionError } from "./errors";
+
+export type ContainerRegistryClientEvent = types.ContainerRegistryClientEvent;
+export type ContainerRegistryClientObserver =
+  types.ContainerRegistryClientObserver;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface DockerPullOptions {
   password?: string;
 
   /**
-   * Additional request options.
+   * Additional request options to be passed to the container registry client.
    */
   reqOptions?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -102,6 +102,11 @@ export interface DockerPullOptions {
    * Set platform if server is multi-platform capable.
    */
   platform?: types.Platform;
+
+  /**
+   * Optional observer to receive events from the container registry client.
+   */
+  observer?: types.ContainerRegistryClientObserver;
 }
 
 export interface SaveRequests {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Upgrades @snyk/docker-registry-v2-client to v3 (^3.0.0) and threads the new optional ContainerRegistryClientObserver through DockerPull.pull() for every registry interaction on the pull path: getManifest, getImageConfig, and each downloadLayer call. 

Adds observer?: types.ContainerRegistryClientObserver to DockerPullOptions so callers can receive client events without changing default behavior when omitted.

Re-exports ContainerRegistryClientObserver and ContainerRegistryClientEvent from @snyk/snyk-docker-pull so consumers can type observers without importing @snyk/docker-registry-v2-client directly in application code.

### Notes for the reviewer

Part of a multi-step rollout of the new SSRF protections. After this commit is merged, I will update DRA to enable the new protections in dry-run mode to monitor the impact. After some monitoring we can then bring this version to the other consumers (`snyk-docker-plugin` and `container-image-collector`).

### More information

- Jira ticket: https://snyksec.atlassian.net/browse/CN-1024

