### PR TITLE
chore: update @snyk/docker-registry-v2-client to v4 with typed options

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "semantic-release": "^19.0.5"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^3.0.0",
+    "@snyk/docker-registry-v2-client": "^4.0.0",
     "child-process": "^1.0.2",
     "tar-fs": "^3.0.9"
   },

--- a/src/docker-pull.ts
+++ b/src/docker-pull.ts
@@ -200,9 +200,7 @@ export class DockerPull {
     repo: string,
     username?: string,
     password?: string,
-    // weak typing on the client
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    reqOptions = {} as any,
+    reqOptions: registryClient.ClientOptions = {},
     observer?: types.ContainerRegistryClientObserver
   ): Promise<Layer[]> {
     return await Promise.all(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
-import type { types } from "@snyk/docker-registry-v2-client";
+import type { types, ClientOptions } from "@snyk/docker-registry-v2-client";
 
 export { DockerPull } from "./docker-pull";
 export { DockerPullOptions, DockerPullResult } from "./types";
 export { InvalidManifestSchemaVersionError } from "./errors";
 
+export type { ClientOptions };
 export type ContainerRegistryClientEvent = types.ContainerRegistryClientEvent;
 export type ContainerRegistryClientObserver =
   types.ContainerRegistryClientObserver;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { types } from "@snyk/docker-registry-v2-client";
+import { types, ClientOptions } from "@snyk/docker-registry-v2-client";
 
 /**
  * Directory Result.
@@ -75,7 +75,7 @@ export interface DockerPullOptions {
   /**
    * Additional request options to be passed to the container registry client.
    */
-  reqOptions?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  reqOptions?: ClientOptions;
 
   /**
    * Load the image into the Docker container runtime. Default: `true`.


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Updates `@snyk/docker-registry-v2-client` dependency to version 4.0.0. This update introduces stronger type safety by replacing the loosely-typed `reqOptions: any` with the structured `ClientOptions` interface provided by the library.

### Notes for the reviewer

Changes:
- Updated `package.json` to the new major version.
- Replaced `any` with `ClientOptions` in `src/types.ts` and `src/docker-pull.ts`.
- Exported `ClientOptions` from the package entry point (`src/index.ts`) so consumers can benefit from the typed options.


### More information

- Jira ticket: https://snyksec.atlassian.net/browse/CN-1024

