### PR TITLE
fix: scope npm publish to dist via files directive (CN-1337)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "CLI-less docker pull",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Adds a `files` allowlist to `package.json` so `npm publish` only ships `dist/`. Right now there's no `files` directive and no `.npmignore`, so the tarball ends up carrying the whole repo — `.circleci/config.yml` with internal CI context names, source under `src/`, plus `.gitleaksignore`, `tsconfig.json`, and the various editor folders. That's the leak that pushed ProdSec to flip the package private on 2026-05-15.

This is the package-side prerequisite for republishing `@snyk/snyk-docker-pull` publicly. After Matt Dolan and Nicholas Vinson aligned over in [#team-cli](https://snyk.slack.com/archives/C06B0PKC0HL/p1779278853679039), the plan is: add the `files` directive, unpublish the leaky versions through NPM Support, then publish a clean version under the same name. This PR is step one.

`["dist"]` is what `@snyk/dep-graph` and `@snyk/docker-registry-v2-client` (a direct dep of this package) already use, so it's the established org convention rather than a guess.

## Verified locally

After `npm run build`, `npm pack --dry-run` ships:

```
README.md
dist/*.{d.ts,js,js.map}   (21 files)
package.json
```

23 files, 9.7 kB. None of the previously-leaked `.circleci/` or repo-internal config makes it in.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm pack --dry-run` confirms only `dist/`, `package.json`, `README.md` ship
- [ ] CI green
- [ ] ProdSec signs off on the contents before flipping visibility back to public

## Related

- Jira: [CN-1337](https://snyksec.atlassian.net/browse/CN-1337)
- Incident: [INC-4725](https://snyksec.atlassian.net/browse/INC-4725) (FireHydrant INC-3164)
- Post-mortem: [INC-4726](https://snyksec.atlassian.net/browse/INC-4726)
- Original ProdSec explanation in [#team-container](https://snyk.slack.com/archives/C08KFUU9R5Z/p1778870447065419?thread_ts=1778848211.222819&cid=C08KFUU9R5Z)

[CN-1337]: https://snyksec.atlassian.net/browse/CN-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ