### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ workflows:
             - Install
           matrix:
             parameters:
-              node-version: ["14.21", "16.19", "18.15"]
+              node-version: ["16.19", "18.15", "20.15"]
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ workflows:
             - Install
           matrix:
             parameters:
-              node-version: ["14.21", "16.19", "18.15"]
+              node-version: ["20.15", "22.14"]
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ workflows:
             - Install
           matrix:
             parameters:
-              node-version: ["20.15", "22.14"]
+              node-version: ["14.21", "16.19", "18.15"]
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,17 +177,16 @@ jobs:
     steps:
       - checkout_and_merge
       - run:
-          name: Use snyk-main npmjs user
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-      - run:
           name: Install dependencies
           command: npm install
       - run:
           name: Build
           command: npm run build
       - run:
-          name: Release on GitHub
-          command: npx semantic-release
+          name: Release
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release
 workflows:
   version: 2
   test_and_release:
@@ -244,7 +243,9 @@ workflows:
 
       - release:
           name: Release to GitHub
-          context: nodejs-lib-release
+          context:
+            - nodejs-install
+            - github-release
           requires:
             - Security Scans
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
           name: Build
           command: npm run build
       - run:
-          name: Release
+          name: Release on GitHub
           command: |
             export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             npx semantic-release

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,9 @@ _Instructions on how to run this locally, background context, what to review, qu
 
 ### More information
 
-- Jira ticket: https://snyksec.atlassian.net/browse/CN-0000
-- Slack thread: https://snyk.slack.com/archives
-- Documentation: N/A
+- Jira ticket: 
+- Slack thread: 
+- Documentation:
 
 ### Screenshots
 

--- a/README.md
+++ b/README.md
@@ -19,18 +19,13 @@ A library that pulls container images.
 ### Local
 
 Set up your local env with the following env vars (see 1Password):
-
+Copy and paste the DRA env values
 ```
-export SNYK_DRA_AZURE_USERNAME=snykgoof
-export SNYK_DRA_AZURE_PASSWORD=<See 1password: Development/Azure Container Registry (ACR) - Docker Registry Agent>
-export SNYK_DRA_AZURE_REPOSITORY=snykgoof/azure-goof
-export SNYK_DRA_AZURE_REGISTRY_BASE=snykgoof.azurecr.io
-
-export SNYK_DRA_DOCKER_HUB_USERNAME=snykgoof
-export SNYK_DRA_DOCKER_HUB_PASSWORD=<See 1password: Development/DockerHub - snykgoof user>
-export SNYK_DRA_DOCKER_HUB_REPOSITORY=snykgoof/dockerhub-goof
-export SNYK_OCI_MULTI_ARCH_DOCKER_HUB_REPOSITORY=snykgoof/nodejs18
-export SNYK_DRA_DOCKER_HUB_REGISTRY_BASE=registry-1.docker.io
+export SNYK_DRA_AZURE_USERNAME=...
+export SNYK_DRA_AZURE_PASSWORD=...
+...
+export SNYK_OCI_MULTI_ARCH_DOCKER_HUB_REPOSITORY=...
+export SNYK_DRA_DOCKER_HUB_REGISTRY_BASE=...
 ```
 
 To run the tests:

--- a/README.md
+++ b/README.md
@@ -10,29 +10,7 @@ A library that pulls container images.
 
 ## Tests
 
-### Infrastructure
-
-| Container Registry      | How to access                                                                                      |
-| ----------------------- | -------------------------------------------------------------------------------------------------- |
-| Docker Hub (docker-hub) | [DockerHub](https://hub.docker.com/), then 1Password: `Development > Okta - team magma Docker Hub` |
-
-### Local
-
-Set up your local env with the following env vars (see 1Password):
-Copy and paste the DRA env values
-```
-export SNYK_DRA_AZURE_USERNAME=...
-export SNYK_DRA_AZURE_PASSWORD=...
-...
-export SNYK_OCI_MULTI_ARCH_DOCKER_HUB_REPOSITORY=...
-export SNYK_DRA_DOCKER_HUB_REGISTRY_BASE=...
-```
-
-To run the tests:
-
-```console
-$ npm run test
-```
+See the internal Confluence page **snyk-docker-pull: Local Testing Setup** for environment variable names, 1Password credential locations, and instructions for running the test suite locally.
 
 ## Linting and formatting
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=20"
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "semantic-release": "^25.0.3"
   },
   "dependencies": {
-    "@snyk/docker-registry-v2-client": "^4.0.0",
+    "@snyk/docker-registry-v2-client": "^4.0.2",
     "child-process": "^1.0.2",
     "tar-fs": "^3.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=12"
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "ts-jest": "^26.5.4",
     "ts-node": "^10.4.0",
     "typescript": "^4.7.4",
-    "semantic-release": "^19.0.5"
+    "@semantic-release/npm": "^13.1.5",
+    "semantic-release": "^25.0.3"
   },
   "dependencies": {
     "@snyk/docker-registry-v2-client": "^4.0.0",


### PR DESCRIPTION
ProdSec is rolling out OIDC Trusted Publishing across Snyk's NPM packages to get rid of long-lived static tokens. They've already done their part for this repo (verified the package on npmjs.com, configured the Trusted Publisher). This PR is our side of the migration.

## What changed

**`.circleci/config.yml`** — the release job no longer writes a static `NPM_TOKEN` into `.npmrc`. Instead it fetches a short-lived OIDC token at runtime via `circleci run oidc get` and exports it as `NPM_ID_TOKEN`, which `@semantic-release/npm` picks up automatically. The job context is also updated: `nodejs-lib-release` is replaced with `nodejs-install` (install auth, same as the other jobs) and `github-release` (GitHub token for tag/release creation, previously bundled inside `nodejs-lib-release`).

The `NPM_TOKEN` writes in the `install_deps` command and the `build` job are intentionally untouched — those are the read-only install token from `nodejs-install` and are out of scope per the ProdSec guide.

**`package.json`** — bumps `semantic-release` from `^19` to `^25` and adds an explicit `@semantic-release/npm@^13.1.5`. OIDC support and automatic provenance attestation landed in `@semantic-release/npm` v13.1.0, so both bumps are required for this to work. Because `@snyk/snyk-docker-pull` is a public package, provenance will show up as a badge on the npmjs.com page after the first publish.

## Merge checklist

- [ ] ProdSec has granted the `github-release` CircleCI context to this repo (blocker — release job fails without it)
- [ ] Post in `#ask-prodsec`: _"What: Migrating to Trusted Publishing / Repo: https://github.com/snyk/snyk-docker-pull"_ and wait for confirmation

Tracks: [CN-1342](https://snyksec.atlassian.net/browse/CN-1342)

[CN-1342]: https://snyksec.atlassian.net/browse/CN-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ