### PR TITLE
fix(ci): bump default Node image to 22.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 defaults: &defaults
   resource_class: small
   docker:
-    - image: cimg/node:20.15
+    - image: cimg/node:22.14
   working_directory: ~/snyk-docker-pull
 
 executors:


### PR DESCRIPTION
`semantic-release` v25 latest patch requires `^22.14.0 || >=24.10.0`. The release job uses the `*defaults` image (`cimg/node:20.15`, Node 20.15.1), which doesn't satisfy that constraint — it hard-errors before `npm publish` runs.

Bumping the default image to `cimg/node:22.14` fixes the release job. Node 22 is active LTS and satisfies the semantic-release engine requirement.

This is the only change in this PR.

Tracks: [CN-1342](https://snyksec.atlassian.net/browse/CN-1342)

[CN-1342]: https://snyksec.atlassian.net/browse/CN-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ